### PR TITLE
Disable start execution button if job is already started

### DIFF
--- a/src/components/Commit.js
+++ b/src/components/Commit.js
@@ -212,7 +212,8 @@ export const CommitDetailComponent = ({repositoryId, commitId}) => {
   return (<CommitDetail id={commitId} title={firstLine} body={otherLines.join('\n')}
                         updated={updated} deleted={deleted} created={created}
                         committer={committer} committedAt={committedAt} repositoryId={repositoryId} commitId={commitId}>
-      <NotebookTreeComponent repositoryId={repositoryId} commitId={commitId} created={created} updated={updated}/>
+      <NotebookTreeComponent repositoryId={repositoryId} commitId={commitId} created={created} updated={updated}
+                             showCheckboxes={false}/>
     </CommitDetail>
   )
 }

--- a/src/components/Executions.js
+++ b/src/components/Executions.js
@@ -137,8 +137,8 @@ export const ExecutionComponent = ({executionId}) => {
           <Grid.Row>
             <Grid.Column textAlign="right">
               {(loading
-                ? <Placeholder/>
-                : <ExecutionButtonGroup
+                  ? <Placeholder/>
+                  : <ExecutionButtonGroup
                     executionId={executionId}
                     jobStatus={data.status}
                     startExecutionCallback={startExecutionAction}
@@ -152,7 +152,8 @@ export const ExecutionComponent = ({executionId}) => {
             {(loading
                 ? <Placeholder/>
                 : <NotebookTreeComponent onSelect={updateExecution} repositoryId={data.repositoryId}
-                                         commitId={data.commitId} disabled={data.status !== "Ready"}/>
+                                         commitId={data.commitId} disabled={data.status !== "Ready"}
+                                         showCheckboxes={true}/>
             )}
           </Grid.Column>
           <Grid.Column width={12}>

--- a/src/components/Executions.js
+++ b/src/components/Executions.js
@@ -106,7 +106,7 @@ export const ExecutionComponent = ({executionId}) => {
     }
   );
 
-  const [{data: startExecutionData, error: startExecutionError, response: startExecutionresponse},
+  const [{data: startExecutionData, error: startExecutionError, loading: startExecutionLoading, response: startExecutionresponse},
     startExecution] = useAxios({
       url: `${env('EXECUTION_HOST')}/api/v1/execution/${executionId}/start`,
       method: 'POST'
@@ -138,7 +138,13 @@ export const ExecutionComponent = ({executionId}) => {
             <Grid.Column textAlign="right">
               {(loading
                 ? <Placeholder/>
-                : <ExecutionButtonGroup executionId={executionId} jobStatus={data.status} startExecutionCallback={startExecutionAction} compact floated='right' />
+                : <ExecutionButtonGroup
+                    executionId={executionId}
+                    jobStatus={data.status}
+                    startExecutionCallback={startExecutionAction}
+                    loading={loading || startExecutionLoading}
+                    compact floated='right'
+                  />
               )}
             </Grid.Column>
           </Grid.Row>
@@ -146,7 +152,7 @@ export const ExecutionComponent = ({executionId}) => {
             {(loading
                 ? <Placeholder/>
                 : <NotebookTreeComponent onSelect={updateExecution} repositoryId={data.repositoryId}
-                                         commitId={data.commitId}/>
+                                         commitId={data.commitId} disabled={data.status !== "Created"}/>
             )}
           </Grid.Column>
           <Grid.Column width={12}>
@@ -165,7 +171,7 @@ export const ExecutionComponent = ({executionId}) => {
   )
 }
 
-const ExecutionButtonGroup = ({executionId, jobStatus, startExecutionCallback, ...rest}) => {
+const ExecutionButtonGroup = ({executionId, jobStatus, startExecutionCallback, loading, ...rest}) => {
 
   const [{data: cancelExecutionData, error: cancelExecutionError, response: cancelExecutionResponse},
     cancelExecution] = useAxios({
@@ -178,8 +184,8 @@ const ExecutionButtonGroup = ({executionId, jobStatus, startExecutionCallback, .
 
   return (
     <Button.Group labeled icon {...rest}>
-      <Button icon='play' content='start' onClick={startExecutionCallback} disabled={jobStatus !== 'Ready'}/>
-      <Button icon='cancel' content='cancel' onClick={cancelExecution} disabled={jobStatus !== 'Running'}/>
+      <Button icon='play' content='start' onClick={startExecutionCallback} disabled={jobStatus !== 'Ready'} loading={loading}/>
+      <Button icon='cancel' content='cancel' onClick={cancelExecution} disabled={jobStatus !== 'Running'} loading={loading}/>
       {/*TODO check if job is running before trying to cancel*/}
     </Button.Group>
   )

--- a/src/components/Executions.js
+++ b/src/components/Executions.js
@@ -152,7 +152,7 @@ export const ExecutionComponent = ({executionId}) => {
             {(loading
                 ? <Placeholder/>
                 : <NotebookTreeComponent onSelect={updateExecution} repositoryId={data.repositoryId}
-                                         commitId={data.commitId} disabled={data.status !== "Created"}/>
+                                         commitId={data.commitId} disabled={data.status !== "Ready"}/>
             )}
           </Grid.Column>
           <Grid.Column width={12}>

--- a/src/components/Notebooks.js
+++ b/src/components/Notebooks.js
@@ -7,7 +7,7 @@ import env from "@beam-australia/react-env";
 import useAxios from "axios-hooks";
 
 // TODO: Refactor
-const makeHierarchy = (notebooks, created, updated) => {
+const makeHierarchy = (notebooks, created, updated, showCheckboxes) => {
 
   const containsChanges = (created, updated, leaf) => {
     return !!(created?.filter(n => n.id === leaf.id).length > 0
@@ -21,26 +21,30 @@ const makeHierarchy = (notebooks, created, updated) => {
       if (created?.length > 0 && created.filter(notebook => notebook.id === leaf.id).length > 0) {
         nodes.push({
           value: leaf.id,
-          label: <span style={{ color: "green" }}>*{folder}</span>
+          label: <span style={{ color: "green" }}>*{folder}</span>,
+          showCheckbox: showCheckboxes
         });
       } else if (updated?.length > 0 && updated.filter(notebook => notebook.id === leaf.id).length > 0) {
         nodes.push({
           value: leaf.id,
-          label: <span style={{ color: "blue" }}>~{folder}</span>
+          label: <span style={{ color: "blue" }}>~{folder}</span>,
+          showCheckbox: showCheckboxes
         });
       } else {
         nodes.push({
           value: leaf.id,
-          label: folder
+          label: folder,
+          showCheckbox: showCheckboxes
         });
       }
     } else {
       let node = nodes.find(e => e.value === folder);
       if (node === undefined) {
         if (containsChanges(created, updated, leaf) === true) {
-          node = { value: folder, label: <span style={{fontWeight: "bold"}}>{folder}</span>, children: [] }
+          node = { value: folder, label: <span style={{fontWeight: "bold"}}>{folder}</span>,
+            children: [], showCheckbox: showCheckboxes }
         } else {
-          node = {value: folder, label: folder, children: []}
+          node = {value: folder, label: folder, children: [], showCheckbox: showCheckboxes}
         }
         nodes.push(node);
       }
@@ -71,7 +75,8 @@ const icons = {
   leaf: <Icon fitted name="file code outline"/>
 }
 
-export const NotebookTree = ({notebooks = [], onSelect = () => {}, created = [], updated = [], disabled}) => {
+export const NotebookTree =
+  ({notebooks = [], onSelect = () => {}, created = [], updated = [], disabled, showCheckboxes}) => {
   const [checked, setChecked] = useState([]);
   const [expanded, setExpanded] = useState([]);
 
@@ -80,7 +85,7 @@ export const NotebookTree = ({notebooks = [], onSelect = () => {}, created = [],
     onSelect(checked);
   }
 
-  return <CheckboxTree nodes={makeHierarchy(notebooks, created, updated)}
+  return <CheckboxTree nodes={makeHierarchy(notebooks, created, updated, showCheckboxes)}
                        icons={icons}
                        checked={checked}
                        expanded={expanded}
@@ -90,7 +95,8 @@ export const NotebookTree = ({notebooks = [], onSelect = () => {}, created = [],
   />
 }
 
-export const NotebookTreeComponent = ({repositoryId, commitId, onSelect, created, updated, disabled}) => {
+export const NotebookTreeComponent =
+  ({repositoryId, commitId, onSelect, created, updated, disabled, showCheckboxes}) => {
 
   const [{data, loading, error}] = useAxios(
     `${env('BLUEPRINT_HOST')}/api/v1/repositories/${repositoryId}/commits/${commitId}/notebooks`
@@ -101,6 +107,12 @@ export const NotebookTreeComponent = ({repositoryId, commitId, onSelect, created
     <Message.Header>Error</Message.Header>
     <p>{JSON.stringify(error)}</p>
   </Message>
-  return <NotebookTree notebooks={data} onSelect={onSelect} created={created} updated={updated} disabled={disabled}/>
+  return <NotebookTree
+    notebooks={data}
+    onSelect={onSelect}
+    created={created}
+    updated={updated}
+    disabled={disabled}
+    showCheckboxes={showCheckboxes}/>
 
 }

--- a/src/components/Notebooks.js
+++ b/src/components/Notebooks.js
@@ -71,7 +71,7 @@ const icons = {
   leaf: <Icon fitted name="file code outline"/>
 }
 
-export const NotebookTree = ({notebooks = [], onSelect = () => {}, created = [], updated = []}) => {
+export const NotebookTree = ({notebooks = [], onSelect = () => {}, created = [], updated = [], disabled}) => {
   const [checked, setChecked] = useState([]);
   const [expanded, setExpanded] = useState([]);
 
@@ -86,10 +86,11 @@ export const NotebookTree = ({notebooks = [], onSelect = () => {}, created = [],
                        expanded={expanded}
                        onCheck={newChecked => select(newChecked)}
                        onExpand={newExpanded => setExpanded(newExpanded)}
+                       disabled={disabled}
   />
 }
 
-export const NotebookTreeComponent = ({repositoryId, commitId, onSelect, created, updated}) => {
+export const NotebookTreeComponent = ({repositoryId, commitId, onSelect, created, updated, disabled}) => {
 
   const [{data, loading, error}] = useAxios(
     `${env('BLUEPRINT_HOST')}/api/v1/repositories/${repositoryId}/commits/${commitId}/notebooks`
@@ -100,6 +101,6 @@ export const NotebookTreeComponent = ({repositoryId, commitId, onSelect, created
     <Message.Header>Error</Message.Header>
     <p>{JSON.stringify(error)}</p>
   </Message>
-  return <NotebookTree notebooks={data} onSelect={onSelect} created={created} updated={updated}/>
+  return <NotebookTree notebooks={data} onSelect={onSelect} created={created} updated={updated} disabled={disabled}/>
 
 }

--- a/src/components/Notebooks.js
+++ b/src/components/Notebooks.js
@@ -1,4 +1,4 @@
-import React, {useState} from 'react'
+import React, { useEffect, useState } from 'react'
 import CheckboxTree from 'react-checkbox-tree';
 import {Dimmer, Icon, Loader, Message} from 'semantic-ui-react'
 
@@ -76,9 +76,13 @@ const icons = {
 }
 
 export const NotebookTree =
-  ({notebooks = [], onSelect = () => {}, created = [], updated = [], disabled, showCheckboxes}) => {
+  ({notebooks = [], onSelect = () => {}, created = [], updated = [], disabled, showCheckboxes, checkedNotebooks}) => {
   const [checked, setChecked] = useState([]);
   const [expanded, setExpanded] = useState([]);
+
+  useEffect(() => {
+    setChecked(checkedNotebooks);
+  }, [checkedNotebooks, setChecked]);
 
   function select(checked) {
     setChecked(checked);
@@ -96,7 +100,7 @@ export const NotebookTree =
 }
 
 export const NotebookTreeComponent =
-  ({repositoryId, commitId, onSelect, created, updated, disabled, showCheckboxes}) => {
+  ({repositoryId, commitId, onSelect, created, updated, disabled, showCheckboxes, checked}) => {
 
   const [{data, loading, error}] = useAxios(
     `${env('BLUEPRINT_HOST')}/api/v1/repositories/${repositoryId}/commits/${commitId}/notebooks`
@@ -113,6 +117,8 @@ export const NotebookTreeComponent =
     created={created}
     updated={updated}
     disabled={disabled}
-    showCheckboxes={showCheckboxes}/>
+    showCheckboxes={showCheckboxes}
+    checkedNotebooks={checked}
+  />
 
 }


### PR DESCRIPTION
Add the following functionality:
- Start button disabled if execution has any other state than `Ready`
- Cancel button disabled if execution has any other state than `Running`
- Set both buttons to loading if waiting for response after click
- Disable checkboxes in execution view if execution has any other state than `Ready`
- Hide checkboxes in notebook tree for Commit view
- Keep checked notebooks after refresh
- Check all dependent notebooks if parent is checked (which means you cannot uncheck a notebook if a parent is checked)